### PR TITLE
Make global flags actually global

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -74,7 +74,7 @@ CXXINCLUDES-$(CONFIG_LIBLVGL) += $(LIBLVGL_INCLUDES)
 LIBLVGL_FLAGS = -DLV_CONF_INCLUDE_SIMPLE
 LIBLVGL_SUPPRESS_FLAGS += -Wno-unused-parameter -Wno-unused-value
 
-LIBLVGL_CFLAGS-y     += $(LIBLVGL_FLAGS)          \
+CFLAGS-y     += $(LIBLVGL_FLAGS)          \
 		        $(LIBLVGL_SUPPRESS_FLAGS)
 
 ################################################################################


### PR DESCRIPTION
Application that tried to use the library failed to build as it could not find the lv_conf.h file without these flags.
The flags would need to be defined by the app unless they are defined global by the lib.

I am unsure if the suppression flags should also be global, but I assume so as they are part of the same global flags section.


Build error message for further reference:
```
CC      appunikraft_lvgl_test: main.o                                                                                                                    
     3% ███▊                                                                                                                           37/1204 [16.51file/s]In file included from /home/user/unikraft/unikraft_lvgl_test/build/liblvgl/origin/lvgl-3429e58d3c40efa47201e03382cbcec1e65d9882/lvgl.h:19,
                 from /home/user/unikraft/unikraft_lvgl_test/main.c:1:
/home/user/unikraft/unikraft_lvgl_test/build/liblvgl/origin/lvgl-3429e58d3c40efa47201e03382cbcec1e65d9882/src/lv_misc/lv_log.h:19:10: fatal error: ../../../lv_conf.h: No such file or directory
   19 | #include "../../../lv_conf.h"
      |          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [/home/user/.unikraft/unikraft/support/build/Makefile.build:27: /home/user/unikraft/unikraft_lvgl_test/build/appunikraft_lvgl_test/main.o] Error 1
make[1]: *** [Makefile:984: sub-make] Error 2
make: *** [Makefile:32: _all] Error 2
```