### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "lvgl"
+description := "An open-source Embedded GUI Library."
+gitrepo     := "https://github.com/littlevgl/lvgl.git"
+homepage    := "https://littlevgl.com"
+license     := "MIT"
+version     := 3429e58 sha256:50f6a3620e119e29357b88d2e692c4bafcb6ff8d2fd7c9c668dd27bb6a49e48c https://github.com/littlevgl/lvgl/archive/3429e58.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

